### PR TITLE
Fix duplicate 'select' text in EditFriendsView

### DIFF
--- a/Vinylogue/Features/UserManagement/EditFriendsView.swift
+++ b/Vinylogue/Features/UserManagement/EditFriendsView.swift
@@ -102,7 +102,7 @@ struct EditFriendsView: View {
                 }
 
                 ToolbarItemGroup(placement: .bottomBar) {
-                    Button("select \(store.selectAllButtonText)") {
+                    Button(store.selectAllButtonText) {
                         store.toggleSelectAll()
                     }
                     .contentTransition(.numericText())


### PR DESCRIPTION
## Summary
- Fixed duplicate "select" text in the select button of EditFriendsView
- Button was showing "select select all" or "select select none" 
- Removed hardcoded "select" prefix since `selectAllButtonText` already includes the full text

## Test plan
- [x] Open EditFriendsView with friends in the list
- [x] Verify select button shows "select all" (not "select select all")
- [x] Tap select button and verify it changes to "select none" (not "select select none")
- [x] Verify button functionality still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)